### PR TITLE
Fix issue with Delete reloading top of Page

### DIFF
--- a/Source/TextboxList.js
+++ b/Source/TextboxList.js
@@ -428,7 +428,7 @@ TextboxListBit.Box = new Class({
 		this.bit.addEvent('click', this.focus.bind(this));
 		if (this.options.deleteButton){
 			this.bit.addClass(this.typeprefix + '-deletable');
-			this.close = new Element('a', {href: '#', 'class': this.typeprefix + '-deletebutton', events: {click: this.remove.bind(this)}}).inject(this.bit);
+			this.close = new Element('a', {href: 'javascript:void(0)', 'class': this.typeprefix + '-deletebutton', events: {click: this.remove.bind(this)}}).inject(this.bit);
 		}
 		this.bit.getChildren().addEvent('click', function(e){ e.stop(); });
   }


### PR DESCRIPTION
In my experience, clicking the delete button on a bit tag, caused the page to reload at the top because it's an anchor tag with an href. This probably shouldn't be an anchor tag, but if it is going to be, we don't want the browser interpreting that click event. So making the `href= "javascript:void(0);"` will stop that. You could also put an `e.stop()` function on the click.
